### PR TITLE
Add extensive inline documentation

### DIFF
--- a/bioverse/__init__.py
+++ b/bioverse/__init__.py
@@ -1,3 +1,9 @@
+"""Convenience re-exports for the Bioverse package.
+
+This module exposes the most commonly used classes and functions at the package
+level so they can be imported directly from :mod:`bioverse`.
+"""
+
 from .constants import (
     num_bio_tokens,
     bio_token_list,

--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -1,3 +1,5 @@
+"""Constant values and special token definitions used throughout Bioverse."""
+
 num_bio_tokens = 2
 bio_token_list = [f"[BIO_{i+1}]" for i in range(num_bio_tokens)]
 
@@ -7,5 +9,12 @@ BIO_END_TOKEN = '[BIO_END]'
 ANSWER_TOKEN = '[ANSWER]'
 
 special_tokens = {
-    'additional_special_tokens': [BIO_START_TOKEN, BIO_END_TOKEN, TRAINABLE_BIO_TOKEN, ANSWER_TOKEN] + bio_token_list
+    # These tokens are appended to the tokenizer so that the language model can
+    # recognise placeholders for biological embeddings as well as answer spans.
+    'additional_special_tokens': [
+        BIO_START_TOKEN,
+        BIO_END_TOKEN,
+        TRAINABLE_BIO_TOKEN,
+        ANSWER_TOKEN,
+    ] + bio_token_list
 }

--- a/bioverse/data.py
+++ b/bioverse/data.py
@@ -1,3 +1,5 @@
+"""Data loading utilities and dataset wrappers for Bioverse."""
+
 import scanpy as sc
 import torch
 from torch.utils.data import Dataset, random_split
@@ -11,9 +13,23 @@ from .constants import num_bio_tokens
 
 
 def load_AnnData_from_file(h5ad_path, use_subset=False):
-    use_subset_ann = use_subset
+    """Load an AnnData object from ``h5ad_path``.
+
+    Parameters
+    ----------
+    h5ad_path : str or Path
+        Location of the ``.h5ad`` file.
+    use_subset : bool, optional
+        If ``True``, randomly sample 20% of the cells to speed up experiments.
+
+    Returns
+    -------
+    AnnData
+        The loaded dataset (or subset).
+    """
+
     adata_all = sc.read_h5ad(h5ad_path)
-    if use_subset_ann:
+    if use_subset:
         adata = adata_all[adata_all.obs.sample(frac=0.2, random_state=42).index, :]
     else:
         adata = adata_all
@@ -27,6 +43,8 @@ class ScRNASeqEncoder(ABC):
 
 
 class MammalEncoder(ScRNASeqEncoder):
+    """Wrapper around the MAMMAL model to produce fixed-length embeddings."""
+
     def __init__(self, mammal_model, mammal_tokenizer, device, num_tokens):
         self.model = mammal_model
         self.tokenizer = mammal_tokenizer
@@ -34,9 +52,16 @@ class MammalEncoder(ScRNASeqEncoder):
         self.num_tokens = num_tokens
 
     def get_cell_embedding(self, genes, expressions) -> torch.Tensor:
+        """Encode a single cell as a fixed-length embedding tensor."""
+
+        # Pick the most highly expressed genes to reduce input length
         top_n = 1024
-        sorted_genes = [gene for _, gene in sorted(zip(expressions, genes), reverse=True) if _ > 0]
+        sorted_genes = [
+            gene for _, gene in sorted(zip(expressions, genes), reverse=True) if _ > 0
+        ]
         top_genes_str = "[" + "][".join(sorted_genes[:top_n]) + "]"
+
+        # Construct the string representation expected by the MAMMAL tokenizer
         sample_dict = dict()
         sample_dict[ENCODER_INPUTS_STR] = (
             f"<@TOKENIZER-TYPE=GENE><MOLECULAR_ENTITY><MOLECULAR_ENTITY_CELL_GENE_EXPRESSION_RANKED>{top_genes_str}<EXPRESSION_DATA_END><EOS>"
@@ -47,6 +72,8 @@ class MammalEncoder(ScRNASeqEncoder):
             key_out_tokens_ids=ENCODER_INPUTS_TOKENS,
             key_out_attention_mask=ENCODER_INPUTS_ATTENTION_MASK,
         )
+
+        # Run the encoder model to obtain hidden states
         tokens = torch.tensor(sample_dict[ENCODER_INPUTS_TOKENS]).unsqueeze(0).to(self.device)
         attention = torch.tensor(sample_dict[ENCODER_INPUTS_ATTENTION_MASK]).unsqueeze(0).to(self.device)
         batch_dict = {
@@ -57,16 +84,22 @@ class MammalEncoder(ScRNASeqEncoder):
         with torch.no_grad():
             output = self.model(batch_dict)
             last_hidden = output["model.out.encoder_last_hidden_state"].squeeze(0)
+
+            # Pad or truncate to ``self.num_tokens`` so that downstream modules
+            # can assume a fixed size
             if last_hidden.size(0) < self.num_tokens:
                 padding = self.num_tokens - last_hidden.size(0)
                 pad = torch.zeros(padding, last_hidden.size(1)).to(self.device)
                 bio_embeddings = torch.cat([last_hidden, pad], dim=0)[: self.num_tokens]
             else:
                 bio_embeddings = last_hidden[: self.num_tokens]
+
         return bio_embeddings
 
 
 class AnnDatasetWithBioEmbedding(Dataset):
+    """PyTorch ``Dataset`` yielding MAMMAL embeddings and labels."""
+
     def __init__(self, adata, bio_encoder: ScRNASeqEncoder, device, label_key="CellType"):
         self.adata = adata
         self.labels = adata.obs[label_key].values
@@ -78,11 +111,13 @@ class AnnDatasetWithBioEmbedding(Dataset):
         return self.adata.shape[0]
 
     def __getitem__(self, idx):
+        # ``AnnData.X`` may store sparse matrices; convert to a dense vector
         expr = (
             self.adata.X[idx].toarray().flatten()
             if hasattr(self.adata.X[idx], "toarray")
             else self.adata.X[idx]
         )
+        # Convert raw gene expression into an embedding using the provided encoder
         bio_embeddings = self.bio_encoder.get_cell_embedding(self.genes, expr)
         return bio_embeddings, self.labels[idx]
 
@@ -90,6 +125,8 @@ class AnnDatasetWithBioEmbedding(Dataset):
 from typing import Tuple
 
 def split_dataset(dataset) -> Tuple[Dataset, Dataset, Dataset]:
+    """Split a dataset into train/dev/test subsets (60/20/20)."""
+
     total_size = len(dataset)
     train_size = int(0.6 * total_size)
     dev_size = int(0.2 * total_size)

--- a/bioverse/models.py
+++ b/bioverse/models.py
@@ -1,3 +1,5 @@
+"""Model loading and architecture components used in Bioverse."""
+
 import torch
 import torch.nn as nn
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -8,6 +10,8 @@ from .constants import num_bio_tokens
 
 
 def loadMammal(model_path, device):
+    """Load the MAMMAL encoder model and tokenizer."""
+
     mammal_model = Mammal.from_pretrained(model_path).eval().to(device)
     mammal_tokenizer = ModularTokenizerOp.from_pretrained(model_path)
     for p in mammal_model.parameters():
@@ -16,6 +20,8 @@ def loadMammal(model_path, device):
 
 
 def loadLLM(model_path, device, use_lora=True):
+    """Load the base language model and optionally apply LoRA adapters."""
+
     llm_model = AutoModelForCausalLM.from_pretrained(model_path).to(device)
     llm_tokenizer = AutoTokenizer.from_pretrained(model_path)
     if use_lora:
@@ -35,12 +41,16 @@ def loadLLM(model_path, device, use_lora=True):
 
 
 class TrainableBIO(nn.Module):
+    """Simple module containing a single trainable embedding vector."""
+
     def __init__(self, dim):
         super().__init__()
         self.embedding = nn.Parameter(torch.randn(dim))
 
 
 class BioToTextProjectionLayer(nn.Module):
+    """Project MAMMAL embeddings into the LLM embedding space."""
+
     def __init__(self, input_dim=768, hidden_dim=1024, target_dim=2048, num_tokens=4):
         super().__init__()
         self.num_tokens = num_tokens
@@ -53,4 +63,5 @@ class BioToTextProjectionLayer(nn.Module):
     def forward(self, x):
         if x.ndim == 2:
             x = x.unsqueeze(1)
+        # ``self.proj`` processes each token embedding independently
         return self.proj(x)

--- a/bioverse/utils.py
+++ b/bioverse/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for embedding injection and model saving/loading."""
+
 import torch
 from .constants import (
     TRAINABLE_BIO_TOKEN,
@@ -8,6 +10,8 @@ from .constants import (
 
 
 def get_token_embeddings(llm_model, input_ids):
+    """Fetch the embedding vectors corresponding to ``input_ids``."""
+
     return llm_model.get_input_embeddings()(input_ids)
 
 
@@ -19,19 +23,26 @@ def inject_bio_and_trainable_tokens(
     trainable_bio_token_embedding,
     tokenizer,
 ):
+    """Inject biological and trainable token embeddings into a prompt."""
+
     trainable_bio_token_id = tokenizer.convert_tokens_to_ids(TRAINABLE_BIO_TOKEN)
     num_bio_tokens = bio_embeddings.shape[1]
     bio_token_ids = [tokenizer.convert_tokens_to_ids(f"[BIO_{j+1}]") for j in range(num_bio_tokens)]
     B, T, D = input_embeds.shape
     projected_bio = adapter(bio_embeddings)
     for i in range(B):
+        # Replace placeholder BIO tokens with projected embeddings
         for j, bio_token_id in enumerate(bio_token_ids):
             bio_pos = (input_ids[i] == bio_token_id).nonzero(as_tuple=True)[0]
             if len(bio_pos) > 0:
                 input_embeds[i, bio_pos[0]] = projected_bio[i, j]
+
+        # Optionally replace the TRAINABLE_BIO token if present
         trainable_pos = (input_ids[i] == trainable_bio_token_id).nonzero(as_tuple=True)[0]
         if len(trainable_pos) > 1:
-            raise ValueError(f"Expected at most one {TRAINABLE_BIO_TOKEN} in sample {i}, found {len(trainable_pos)}")
+            raise ValueError(
+                f"Expected at most one {TRAINABLE_BIO_TOKEN} in sample {i}, found {len(trainable_pos)}"
+            )
         if len(trainable_pos) == 1:
             input_embeds[i, trainable_pos.item()] = trainable_bio_token_embedding
     return input_embeds
@@ -48,13 +59,24 @@ def inject_and_tokenize(
     device,
     max_length=64,
 ):
+    """Tokenize prompts and inject biological embeddings into them."""
+
     B = bio_embeddings.size(0)
     bio_embeddings = bio_embeddings.to(device)
+
+    # Build the full prompt for each sample
     if labels is not None:
         full_texts = [f"{prompt_text} {label}" for label in labels]
     else:
         full_texts = [prompt_text] * B
-    tokenized = tokenizer(full_texts, return_tensors="pt", padding=True, truncation=True, max_length=max_length)
+    # Tokenize using the LLM tokenizer
+    tokenized = tokenizer(
+        full_texts,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=max_length,
+    )
     input_ids = tokenized.input_ids.to(device)
     attention_mask = tokenized.attention_mask.to(device)
     embeds = get_token_embeddings(llm_model, input_ids)
@@ -70,6 +92,8 @@ def inject_and_tokenize(
 
 
 def mask_prompt_loss(input_ids, tokenizer, loss_start_token=ANSWER_TOKEN):
+    """Mask tokens so that loss is only computed on the answer portion."""
+
     labels = input_ids.clone()
     B, T = labels.shape
     loss_start_id = tokenizer.convert_tokens_to_ids(loss_start_token)
@@ -83,6 +107,8 @@ def mask_prompt_loss(input_ids, tokenizer, loss_start_token=ANSWER_TOKEN):
 
 
 def save_trained_models(llm_model, llm_tokenizer, b2t_projection_layer, trainable_bio_module, checkpoint_dir, use_lora=True):
+    """Persist the fine-tuned model components to ``checkpoint_dir``."""
+
     final_model_dir = checkpoint_dir / "final_model"
     final_model_dir.mkdir(parents=True, exist_ok=True)
     adapter_path = final_model_dir / "mammal_to_llm_adapter.pt"
@@ -102,6 +128,8 @@ def save_trained_models(llm_model, llm_tokenizer, b2t_projection_layer, trainabl
 
 
 def loadSavedModels(save_model_dir, device):
+    """Load model components previously saved with :func:`save_trained_models`."""
+
     from transformers import AutoConfig, AutoTokenizer, AutoModelForCausalLM
     from .models import BioToTextProjectionLayer, TrainableBIO
     from .constants import num_bio_tokens

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,3 +1,11 @@
+"""Evaluation script for the Bioverse models.
+
+This module loads the pre-trained models and runs them on a held-out test set in
+order to compute various metrics. The evaluation routine largely mirrors the
+training and inference pipelines but disables gradient computation and performs
+no parameter updates.
+"""
+
 from datetime import datetime
 from pathlib import Path
 import torch
@@ -25,12 +33,25 @@ from bioverse import (
 
 
 def main():
+    """Entry point for running model evaluation."""
+
+    # Directory containing the trained model artifacts
     checkpoint_dir = Path("checkpoints")
+
+    # Select the appropriate device; prefer GPU if available
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    bio_tokens = f"{BIO_START_TOKEN} {' '.join(bio_token_list)} {TRAINABLE_BIO_TOKEN} {BIO_END_TOKEN}"
+
+    # Compose the full prompt that will be fed to the LLM. The tokens between
+    # ``BIO_START_TOKEN`` and ``BIO_END_TOKEN`` will be replaced by embeddings of
+    # biological expression data at runtime.
+    bio_tokens = (
+        f"{BIO_START_TOKEN} {' '.join(bio_token_list)} {TRAINABLE_BIO_TOKEN} {BIO_END_TOKEN}"
+    )
     query = "What cell type is this?"
     input_text = f"{query} {bio_tokens} {ANSWER_TOKEN}"
 
+    # Initialize a ClearML task for experiment tracking. This allows logging of
+    # metrics and artifacts in a reproducible manner.
     task = Task.init(
         project_name="MAMMAL-Granite",
         task_name="Eval_" + datetime.now().strftime("%Y%m%d_%H%M%S"),
@@ -38,17 +59,45 @@ def main():
     )
     logger = Logger.current_logger()
 
+    # Load the trained language model, tokenizer and projection layers from disk
     save_model_dir = checkpoint_dir / "final_model"
-    llm_model, llm_tokenizer, b2t_projection_layer, trainable_bio_module = loadSavedModels(save_model_dir, device)
+    (
+        llm_model,
+        llm_tokenizer,
+        b2t_projection_layer,
+        trainable_bio_module,
+    ) = loadSavedModels(save_model_dir, device)
 
-    remote_root_data_path = '/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/'
-    h5ad_path = remote_root_data_path + '/batch_effect/human_pbmc/h5ad/standardized.h5ad'
+    # Path to the annotated data matrix (AnnData) used for evaluation. Only a
+    # standardised human PBMC dataset is used here but this could be replaced
+    # with any compatible dataset.
+    remote_root_data_path = (
+        '/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/'
+    )
+    h5ad_path = (
+        remote_root_data_path + '/batch_effect/human_pbmc/h5ad/standardized.h5ad'
+    )
     adata = load_AnnData_from_file(h5ad_path, use_subset=False)
-    mammal_model, mammal_tokenizer = loadMammal("ibm/biomed.omics.bl.sm.ma-ted-458m", device)
-    mammal_encoder = MammalEncoder(mammal_model, mammal_tokenizer, device, num_bio_tokens)
-    dataset = AnnDatasetWithBioEmbedding(adata, mammal_encoder, device, label_key="CellType")
+    # Load the MAMMAL encoder and create a dataset that yields a MAMMAL
+    # embedding for each cell alongside its ground-truth label.
+    mammal_model, mammal_tokenizer = loadMammal(
+        "ibm/biomed.omics.bl.sm.ma-ted-458m", device
+    )
+    mammal_encoder = MammalEncoder(
+        mammal_model,
+        mammal_tokenizer,
+        device,
+        num_bio_tokens,
+    )
+    dataset = AnnDatasetWithBioEmbedding(
+        adata,
+        mammal_encoder,
+        device,
+        label_key="CellType",
+    )
     _, _, test_dataset = split_dataset(dataset)
     test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
+    # Run evaluation which prints metrics and logs them to ClearML.
     evaluate_model(
         llm_model,
         b2t_projection_layer,

--- a/infer.py
+++ b/infer.py
@@ -1,3 +1,10 @@
+"""Run inference on a subset of the evaluation dataset.
+
+This script loads the trained models and randomly selects several samples from
+the dataset. For each sample a prediction is generated and logged via ClearML.
+It is primarily meant for quick qualitative checks of the model output.
+"""
+
 from datetime import datetime
 from pathlib import Path
 import random
@@ -26,12 +33,22 @@ from bioverse import (
 
 
 def main():
+    """Entry point for running ad-hoc inference."""
+
+    # Folder that stores the trained model checkpoints
     checkpoint_dir = Path("checkpoints")
+
+    # Determine computation device
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    bio_tokens = f"{BIO_START_TOKEN} {' '.join(bio_token_list)} {TRAINABLE_BIO_TOKEN} {BIO_END_TOKEN}"
+
+    # Compose the prompt template used for inference
+    bio_tokens = (
+        f"{BIO_START_TOKEN} {' '.join(bio_token_list)} {TRAINABLE_BIO_TOKEN} {BIO_END_TOKEN}"
+    )
     query = "What cell type is this?"
     prompt_text = f"{query} {bio_tokens} {ANSWER_TOKEN}"
 
+    # ClearML task for experiment tracking
     task = Task.init(
         project_name="MAMMAL-Granite",
         task_name="Infer_" + datetime.now().strftime("%Y%m%d_%H%M%S"),
@@ -39,17 +56,42 @@ def main():
     )
     logger = Logger.current_logger()
 
+    # Load the fine-tuned model components
     save_model_dir = checkpoint_dir / "final_model"
-    llm_model, llm_tokenizer, b2t_projection_layer, trainable_bio_module = loadSavedModels(save_model_dir, device)
+    (
+        llm_model,
+        llm_tokenizer,
+        b2t_projection_layer,
+        trainable_bio_module,
+    ) = loadSavedModels(save_model_dir, device)
 
-    remote_root_data_path = '/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/'
-    h5ad_path = remote_root_data_path + '/batch_effect/human_pbmc/h5ad/standardized.h5ad'
+    # Load the evaluation data. Here a standardised PBMC dataset is used.
+    remote_root_data_path = (
+        '/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/'
+    )
+    h5ad_path = (
+        remote_root_data_path + '/batch_effect/human_pbmc/h5ad/standardized.h5ad'
+    )
     adata = load_AnnData_from_file(h5ad_path, use_subset=False)
-    mammal_model, mammal_tokenizer = loadMammal("ibm/biomed.omics.bl.sm.ma-ted-458m", device)
-    mammal_encoder = MammalEncoder(mammal_model, mammal_tokenizer, device, num_bio_tokens)
-    dataset = AnnDatasetWithBioEmbedding(adata, mammal_encoder, device, label_key="CellType")
+    # Prepare a dataset that returns a MAMMAL embedding for each cell
+    mammal_model, mammal_tokenizer = loadMammal(
+        "ibm/biomed.omics.bl.sm.ma-ted-458m", device
+    )
+    mammal_encoder = MammalEncoder(
+        mammal_model,
+        mammal_tokenizer,
+        device,
+        num_bio_tokens,
+    )
+    dataset = AnnDatasetWithBioEmbedding(
+        adata,
+        mammal_encoder,
+        device,
+        label_key="CellType",
+    )
     _, _, test_dataset = split_dataset(dataset)
 
+    # Randomly sample a subset of cells for demonstration purposes
     random_indices = random.sample(range(len(test_dataset)), 50)
     for idx in random_indices:
         bio_embeddings, label = test_dataset[idx]
@@ -62,7 +104,9 @@ def main():
             bio_embeddings,
             device,
         )
-        logger.report_text(f"[{idx}] Predicted: {prediction} | Ground Truth: {label}")
+        logger.report_text(
+            f"[{idx}] Predicted: {prediction} | Ground Truth: {label}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand module-level docstrings and comments across the codebase
- document training, inference and evaluation scripts
- explain dataset handling and utility functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877e54652a8832fb77de388898c5da3