### PR TITLE
Add multi-cell selection and inference server

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -2,8 +2,9 @@
 
 This demo uses [Dash](https://dash.plotly.com/) to visualise a scRNA-seq dataset
 and [Langflow](https://github.com/logspace-ai/langflow) for LLM integration.
-Users can select a single cell from a scatter plot, provide a question and obtain
-an answer generated via a Langflow workflow.
+Users can select one or more cells using the lasso tool on the scatter plot,
+provide a question and obtain cell type predictions via the Langflow workflow
+or the built in prediction server.
 
 ## Running
 
@@ -19,6 +20,12 @@ To launch the stand-alone Dash demo run:
 python app.py
 ```
 
+The inference server can be started with:
+
+```bash
+python mcp_server.py
+```
+
 ### Running inside Langflow
 
 To start Langflow with the single-cell browser mounted under `/cells` run:
@@ -28,5 +35,7 @@ python langflow_server.py
 ```
 
 A browser window will open showing the UMAP projection of the example dataset.
-Select a cell, enter a question and press **Submit** to send the request through
-the Langflow workflow and display the response.
+Select one or more cells using the lasso tool, enter a question and press
+**Submit** to send the request through the Langflow workflow and display the
+predicted cell type(s).
+

--- a/app/flow.json
+++ b/app/flow.json
@@ -1,0 +1,7 @@
+{
+  "version": "1",
+  "description": "Bioverse inference flow",
+  "config": {
+    "endpoint": "http://localhost:8000/predict"
+  }
+}

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import torch
+import scanpy as sc
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from bioverse import (
+    loadMammal,
+    MammalEncoder,
+    num_bio_tokens,
+    loadSavedModels,
+    run_inference,
+    BIO_START_TOKEN,
+    BIO_END_TOKEN,
+    TRAINABLE_BIO_TOKEN,
+    ANSWER_TOKEN,
+    bio_token_list,
+)
+
+app = FastAPI()
+
+# Load dataset and models once at startup
+adata = sc.datasets.pbmc68k_reduced()
+if "X_umap" not in adata.obsm:
+    sc.pp.neighbors(adata)
+    sc.tl.umap(adata)
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# Adjust the checkpoint path as needed
+try:
+    llm_model, tokenizer, adapter, trainable_bio = loadSavedModels(
+        Path("checkpoints/final_model"), device
+    )
+    mammal_model, mammal_tokenizer = loadMammal(
+        "ibm/biomed.omics.bl.sm.ma-ted-458m", device
+    )
+    encoder = MammalEncoder(mammal_model, mammal_tokenizer, device, num_bio_tokens)
+except Exception as e:  # pragma: no cover - optional model loading
+    llm_model = tokenizer = adapter = trainable_bio = encoder = None
+
+BIO_TOKENS = f"{BIO_START_TOKEN} {' '.join(bio_token_list)} {TRAINABLE_BIO_TOKEN} {BIO_END_TOKEN}"
+
+
+class PredictRequest(BaseModel):
+    cells: List[int]
+    question: str
+
+
+@app.post("/predict")
+def predict(req: PredictRequest):
+    if any(v is None for v in [llm_model, adapter, tokenizer, trainable_bio, encoder]):
+        return {"predictions": []}
+    preds = []
+    for idx in req.cells:
+        expr = (
+            adata.X[idx].toarray().flatten()
+            if hasattr(adata.X[idx], "toarray")
+            else adata.X[idx]
+        )
+        embedding = encoder.get_cell_embedding(adata.var_names.tolist(), expr)
+        prompt = f"{req.question} {BIO_TOKENS} {ANSWER_TOKEN}"
+        pred = run_inference(
+            llm_model,
+            adapter,
+            tokenizer,
+            trainable_bio,
+            prompt,
+            embedding,
+            device,
+        )
+        preds.append(pred)
+    return {"predictions": preds}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,4 +2,6 @@ langflow
 scanpy
 plotly
 dash
+fastapi
+requests
 uvicorn


### PR DESCRIPTION
## Summary
- allow lasso selection of multiple cells
- forward selected cells and question to a local prediction server
- provide FastAPI based `mcp_server` that wraps `inference.run_inference`
- update documentation and requirements

## Testing
- `python -m py_compile app/app.py app/langflow_server.py app/mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_687f735e4af4832f80b260d6fcd6e99b