### PR TITLE
Check flow.json for workflow data

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -6,6 +6,12 @@ Users can select one or more cells using the lasso tool on the scatter plot,
 provide a question and obtain cell type predictions via the Langflow workflow
 or the built in prediction server.
 
+The application reads a `flow.json` file from this directory. If the JSON
+contains a `data` field the corresponding Langflow workflow is loaded. When the
+file only includes a `config` section with an `endpoint`, the app skips loading
+the workflow and forwards requests to that MCP endpoint (default
+`http://localhost:8000/predict`).
+
 ## Running
 
 Install the required packages:

--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,7 @@
 """Dash app demonstrating scRNA‑seq + LLM integration via Langflow."""
 
 from pathlib import Path
+import json
 import dash
 from dash import dcc, html
 from dash.dependencies import Input, Output
@@ -37,11 +38,18 @@ app.layout = html.Div([
 # --- Load Langflow workflow
 FLOW_PATH = Path(__file__).parent / "flow.json"
 flow = None
+PREDICT_URL = "http://localhost:8000/predict"
 if FLOW_PATH.exists():
-    flow = load_flow_from_json(str(FLOW_PATH), build=False)
+    try:
+        flow_json = json.loads(FLOW_PATH.read_text())
+        if "config" in flow_json and "endpoint" in flow_json["config"]:
+            PREDICT_URL = flow_json["config"]["endpoint"]
+        if "data" in flow_json:
+            flow = load_flow_from_json(str(FLOW_PATH), build=False)
+    except Exception:
+        pass
 
 # --- Langflow query handler
-PREDICT_URL = "http://localhost:8000/predict"
 
 
 def query_langflow(cell_indices: List[int], question: str) -> str:


### PR DESCRIPTION
## Summary
- handle cases where `flow.json` only contains endpoint config
- fall back to MCP server when there is no `data` field
- document flow loading behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa36b176c832f942367e4368e20d4