### PR TITLE
Make dataset path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ installed.
    rate or number of epochs.
 2. Download or provide an AnnData `.h5ad` file compatible with the
    `load_AnnData_from_file` function in `bioverse.data`.
-3. Start training:
+3. Start training (optionally specify the dataset path):
 
    ```bash
-   python train.py
+   python train.py --data path/to/your_dataset.h5ad
    ```
 
    Checkpoints are written to the `checkpoints/` directory. After training the
@@ -50,7 +50,7 @@ installed.
 Once a model has been trained you can compute metrics on a test set:
 
 ```bash
-python evaluate.py
+python evaluate.py --data path/to/your_dataset.h5ad
 ```
 
 Results are printed to the console and logged to ClearML if it is
@@ -59,7 +59,7 @@ configured.
 ## Running ad‑hoc inference
 
 ```bash
-python infer.py
+python infer.py --data path/to/your_dataset.h5ad
 ```
 
 This loads the saved model and prints predictions for a random subset of

--- a/evaluate.py
+++ b/evaluate.py
@@ -8,6 +8,7 @@ no parameter updates.
 
 from datetime import datetime
 from pathlib import Path
+import argparse
 import torch
 from clearml import Task, Logger
 from torch.utils.data import DataLoader
@@ -34,6 +35,15 @@ from bioverse import (
 
 def main():
     """Entry point for running model evaluation."""
+
+    parser = argparse.ArgumentParser(description="Evaluate Bioverse models")
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/batch_effect/human_pbmc/h5ad/standardized.h5ad",
+        help="Path to an AnnData .h5ad file",
+    )
+    args = parser.parse_args()
 
     # Directory containing the trained model artifacts
     checkpoint_dir = Path("checkpoints")
@@ -71,13 +81,8 @@ def main():
     # Path to the annotated data matrix (AnnData) used for evaluation. Only a
     # standardised human PBMC dataset is used here but this could be replaced
     # with any compatible dataset.
-    remote_root_data_path = (
-        '/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/'
-    )
-    h5ad_path = (
-        remote_root_data_path + '/batch_effect/human_pbmc/h5ad/standardized.h5ad'
-    )
-    adata = load_AnnData_from_file(h5ad_path, use_subset=False)
+    # Load the evaluation data. ``args.data`` can point to any compatible AnnData file.
+    adata = load_AnnData_from_file(args.data, use_subset=False)
     # Load the MAMMAL encoder and create a dataset that yields a MAMMAL
     # embedding for each cell alongside its ground-truth label.
     mammal_model, mammal_tokenizer = loadMammal(

--- a/infer.py
+++ b/infer.py
@@ -7,6 +7,7 @@ It is primarily meant for quick qualitative checks of the model output.
 
 from datetime import datetime
 from pathlib import Path
+import argparse
 import random
 import torch
 from clearml import Task, Logger
@@ -34,6 +35,15 @@ from bioverse import (
 
 def main():
     """Entry point for running ad-hoc inference."""
+
+    parser = argparse.ArgumentParser(description="Run inference with Bioverse")
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/batch_effect/human_pbmc/h5ad/standardized.h5ad",
+        help="Path to an AnnData .h5ad file",
+    )
+    args = parser.parse_args()
 
     # Folder that stores the trained model checkpoints
     checkpoint_dir = Path("checkpoints")
@@ -65,14 +75,8 @@ def main():
         trainable_bio_module,
     ) = loadSavedModels(save_model_dir, device)
 
-    # Load the evaluation data. Here a standardised PBMC dataset is used.
-    remote_root_data_path = (
-        '/dccstor/bmfm-targets/data/omics/transcriptome/scRNA/finetune/'
-    )
-    h5ad_path = (
-        remote_root_data_path + '/batch_effect/human_pbmc/h5ad/standardized.h5ad'
-    )
-    adata = load_AnnData_from_file(h5ad_path, use_subset=False)
+    # Load the evaluation data; ``args.data`` allows overriding the default path.
+    adata = load_AnnData_from_file(args.data, use_subset=False)
     # Prepare a dataset that returns a MAMMAL embedding for each cell
     mammal_model, mammal_tokenizer = loadMammal(
         "ibm/biomed.omics.bl.sm.ma-ted-458m", device


### PR DESCRIPTION
## Summary
- allow specifying dataset location with `--data`
- document dataset argument in README

## Testing
- `find . -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6880240f56d8832f89ba02cd63a85994