### PR TITLE
Add project requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ installed.
    while:
 
    ```bash
-   pip install -r app/requirements.txt
+   pip install -r requirements.txt
    ```
+
+   The demo application under `app/` has a separate requirements file that
+   should be installed in addition to the base dependencies when running the
+   web UI.
 
 ## Training a model
 
@@ -73,9 +77,11 @@ FastAPI server.
 
 ```bash
 cd app
+pip install -r requirements.txt
 python app.py            # launches the Dash front end on port 8051
 python mcp_server.py     # optional: start the FastAPI server on port 8000
 ```
 
 Open <http://localhost:8051> in your browser to interact with the demo.
+
 

--- a/app/README.md
+++ b/app/README.md
@@ -14,9 +14,11 @@ the workflow and forwards requests to that MCP endpoint (default
 
 ## Running
 
-Install the required packages:
+Install the required packages (base dependencies come from the project
+root):
 
 ```bash
+pip install -r ../requirements.txt
 pip install -r requirements.txt
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Core dependencies
+torch
+transformers
+peft
+clearml
+mammal
+fuse
+scanpy
+scikit-learn
+matplotlib
+numpy
+tqdm
+
+# Web and demo application
+langflow
+dash
+plotly
+fastapi
+pydantic
+requests
+uvicorn
+


### PR DESCRIPTION
## Summary
- add a project-wide `requirements.txt`
- mention installing this file in README
- instruct app README to install both base and app-specific requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68802411273c832f82d2ae78764f91a9