### PR TITLE
Remove unused numpy imports

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,6 @@ import requests
 from typing import List
 import plotly.express as px
 import scanpy as sc
-import numpy as np
 
 # ✅ Updated import based on current Langflow structure
 from langflow.load import load_flow_from_json

--- a/app/langflow_server.py
+++ b/app/langflow_server.py
@@ -8,7 +8,6 @@ import requests
 from typing import List
 import plotly.express as px
 import scanpy as sc
-import numpy as np
 from fastapi.middleware.wsgi import WSGIMiddleware
 
 try:

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -10,7 +10,6 @@ forward pass. This keeps latency low and avoids repeated initialisation.
 from pathlib import Path
 from typing import List
 
-import numpy as np
 import torch
 import scanpy as sc
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- clean up stray `numpy` imports in app modules

## Testing
- `python -m py_compile app/app.py app/mcp_server.py app/langflow_server.py`
- `ruff check app/app.py app/mcp_server.py app/langflow_server.py` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_68802415c598832f849d583127be06be