### PR TITLE
Remove unused imports

### DIFF
--- a/bioverse/data.py
+++ b/bioverse/data.py
@@ -9,7 +9,6 @@ from mammal.keys import (
     ENCODER_INPUTS_ATTENTION_MASK,
 )
 from abc import ABC, abstractmethod
-from .constants import num_bio_tokens
 
 
 def load_AnnData_from_file(h5ad_path, use_subset=False):

--- a/bioverse/evaluation.py
+++ b/bioverse/evaluation.py
@@ -3,6 +3,7 @@
 from sklearn.metrics import accuracy_score, f1_score, classification_report
 from tqdm import tqdm
 from clearml import Logger, Task
+import torch
 from torch import autocast
 from .utils import inject_and_tokenize
 

--- a/bioverse/models.py
+++ b/bioverse/models.py
@@ -6,7 +6,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import get_peft_model, LoraConfig, TaskType
 from mammal.model import Mammal
 from fuse.data.tokenizers.modular_tokenizer.op import ModularTokenizerOp
-from .constants import num_bio_tokens
 
 
 def loadMammal(model_path, device):

--- a/bioverse/utils.py
+++ b/bioverse/utils.py
@@ -3,8 +3,6 @@
 import torch
 from .constants import (
     TRAINABLE_BIO_TOKEN,
-    BIO_START_TOKEN,
-    BIO_END_TOKEN,
     ANSWER_TOKEN,
 )
 


### PR DESCRIPTION
## Summary
- clean up unused imports in main Bioverse modules
- add missing torch import in evaluation utils

## Testing
- `flake8 bioverse/data.py bioverse/evaluation.py bioverse/models.py bioverse/utils.py | grep F401`

------
https://chatgpt.com/codex/tasks/task_e_688159af7cf8832f86c6753e104381fa